### PR TITLE
Fix Speakers Page

### DIFF
--- a/bower_components/bootstrap/dist/css/bootstrap.css
+++ b/bower_components/bootstrap/dist/css/bootstrap.css
@@ -2549,6 +2549,22 @@ table th[class*="col-"] {
   background-color: #ECFFBF;
 }
 
+/* Add background color to keynote speakers */
+
+.keynote-bg {
+	background-color: #FFEEBC;	
+}
+
+.keynote-tag  {
+	background-color: #E1784A;
+	color: #fff;
+	text-align: center;
+	width: 80%;
+	padding: 2px 2px 5px 2px;
+	margin: 20px auto 0;
+	
+}
+
 .collaboration {
   background-color: #C2E8AE;
 }
@@ -5293,17 +5309,19 @@ a.thumbnail.active {
 }
 
 .speaker-keynote {
+  
   border-style: solid;
-  border-color: #F22F52;
-  border-width: 1.5px;
+  border-color: #E1784A;
+  border-width: 4px;
+  /*
   -moz-box-shadow: 2px 2px 5px #888;
   -webkit-box-shadow: 2px 2px 5px #888;
-  box-shadow: 2px 2px 5px #888;
-  transition: color 0.5s ease;
+  box-shadow: 2px 2px 5px #888;*/
+  /*transition: color 0.5s ease; */
 }
 
 .speaker-keynote:hover {
-  color: #F22F52;
+  /*color: #F22F52; */
 }
 
 .media-right,

--- a/speakers.html
+++ b/speakers.html
@@ -91,7 +91,7 @@
                 </li>
               </li>
               <li role="presentation"><a href="mailto:contact@opensourceopensociety.com" target="_blank">Contact</a></li>
-              <li><a href="http://chalkle.com/osos/open-source-open-society-conference/4605" target="_blank">Buy tickets!</a></li>
+              <li><a href="http://chalkle.com/osos/open-source-open-society-conference/4605" target="_blank">Buy Tickets</a></li>
             </ul>
           </nav>
           <img class="img-nav pull-left" src="/img/nav_logo.png"><h3 class="text-muted">//speakers.</h3>
@@ -100,13 +100,13 @@
         <div class="jumbotron">
           <h1>Global leaders and local champions.</h1>
           <p class="lead">What happens when we open source everything?</p>
-          <p><a class="btn btn-lg btn-success" href="http://chalkle.com/osos/open-source-open-society-conference/4605" role="button" target="_blank">Buy tickets to find out.</a></p>
+          <p><a class="btn btn-lg btn-success" href="http://chalkle.com/osos/open-source-open-society-conference/4605" role="button" target="_blank">Buy tickets</a></p>
         </div>
 
         <!-- speakers info here as media-object -->
         <div>
           <h3 align="center"> We're building a stage for world-leading practitioners and the brightest local minds, across open education, business, government and technology. More local speakers to be announced soon.</h3>
-          <p align="center">Red border denotes keynote speakers</p>
+   
         </div>
 
         <br>
@@ -144,18 +144,20 @@
             </div>
           </div>
 
-          <div class="media speaker-keynote">
-            <div class="media-left">
+          <div class="media speaker-keynote keynote-bg">
+            <div class="media-left keynote-bg">
               <a href="http://twitter.com/bkeepers">
                 <img class="media-object" src="./img/speakers/brandon.jpg" alt="Brandon Keepers">
               </a>
             </div>
-            <div class="media-body">
+            <div class="media-body keynote-bg">
               <h4 class="media-heading">Brandon Keepers - Head of open source at GitHub (INTL)</h4>
               <p>
                 GitHub has changed the way open source is built, and Brandon is changing the way GitHub builds open source. An engineer by trade, he believes open source is a fundamental to building great products, and great products sustain healthy open source projects. He shares his endeavours on twitter as @bkeepers and on his blog at opensoul.org.
               </p>
+              <h4 class="keynote-tag">Keynote Speaker</h4> 
             </div>
+ 
           </div>
 
           <div class="media">
@@ -168,24 +170,25 @@
               <h4 class="media-heading">Doug Kirkpatrick - Morning Star Self Management Institute (INTL)</h4>
               <p>
                 Doug Kirkpatrick is the author of BEYOND EMPOWERMENT: THE AGE OF THE SELF-MANAGED ORGANIZATION, available on Amazon.com. He is an organizational change consultant, TEDx and keynote speaker, executive coach, writer and educator. He holds degrees in economics and law, and has a Senior Professional in Human Resources (SPHR®) designation with the Society for Human Resource Management. He currently serves as a director for the Association for Talent Development (ATD, formerly ASTD), the world’s largest talent development association, with over 40,000 members in 120+ countries. 
-                He played the first season of his business career in the manufacturing sector, principally with The Morning Star Company of Sacramento, California, a world leader in the food industry, as a financial controller and administrator. He now engages with the Morning Star Self-Management Institute, the Center for Innovative Cultures, Great Work Cultures and other vibrant organizations and leaders to co-create the future of management.
+                He played the first season of his business career in the manufacturing sector, principally with The Morning Star Company of Sacramento, California, a world leader in the food industry, as a financial controller and administrator. He now engages with the Morning Star Self-Management Institute, the Center for Innovative Cultures, Great Work Cultures and other vibrant organisations and leaders to co-create the future of management.
                 <br>
                 He enjoys travel in rough parts of the world and appreciates the perspective he gains from it.
               </p>
             </div>
           </div>
 
-          <div class="media speaker-keynote">
-            <div class="media-left">
+          <div class="media speaker-keynote keynote-bg">
+            <div class="media-left keynote-bg">
               <a href="http://twitter.com/">
                 <img class="media-object" src="./img/speakers/craig.jpg" alt="Craig Ambrose">
               </a>
             </div>
-            <div class="media-body">
+            <div class="media-body keynote-bg">
               <h4 class="media-heading">Craig Ambrose - Enspiral Craftworks (NZ)</h4>
               <p>
                 Craig is passionate about ecovillages, permaculture and hand crafts. During the day he builds software with Enspiral Craftworks, a non hierarchical collective of software professionals with a focus on social enterprise clients. By night he builds furniture with hand tools, and helps with facilitation and community processes at Atamai Ecovillage. 
               </p>
+                <h4 class="keynote-tag">Keynote Speaker</h4> 
             </div>
           </div>
 
@@ -233,13 +236,13 @@
             </div>
           </div>
 
-          <div class="media speaker-keynote">
-            <div class="media-left">
+          <div class="media speaker-keynote keynote-bg">
+            <div class="media-left keynote-bg">
               <a href="http://twitter.com/lightweight">
                 <img class="media-object" src="./img/speakers/dave_lane.jpg" alt="Dave Lane">
               </a>
             </div>
-            <div class="media-body">
+            <div class="media-body keynote-bg">
               <h4 class="media-heading">Dave Lane - President, New Zealand Open Source Society (NZ)</h4>
               <p>
                 Dave Lane is President of the NZ Open Source Society, and an advocate of
@@ -255,6 +258,7 @@
                 "permissionless innovation" are, and he has been advocating for "open"
                 since long before it was cool.
               </p>
+              <h4 class="keynote-tag">Keynote Speaker</h4> 
             </div>
           </div>
 
@@ -410,41 +414,43 @@
               </div>
             </div>
 
-            <div class="media speaker-keynote">
-              <div class="media-left">
+            <div class="media speaker-keynote keynote-bg">
+              <div class="media-left keynote-bg">
                 <a href="http://twitter.com/saschameinrath">
                   <img class="media-object" src="./img/speakers/sascha.jpg" alt="Sascha Meinrath">
                 </a>
               </div>
-              <div class="media-body">
+              <div class="media-body keynote-bg">
                 <h4 class="media-heading">Sascha Meinrath – Founder, Open Technology Institute (INTL)</h4>
                 <p>
                   Sascha Meinrath has been described as a “community Internet pioneer” and an “entrepreneurial visionary.” He is Director of X-Lab, focusing on thought-provoking, bold tech policy interventions. He also founded the Open Technology Institute and was named to the “TIME Tech 40” in 2013 as one of the most influential figures in technology.
                 </p>
+                <h4 class="keynote-tag">Keynote Speaker</h4>
               </div>
             </div>
 
-            <div class="media speaker-keynote">
-              <div class="media-left">
+            <div class="media speaker-keynote keynote-bg">
+              <div class="media-left keynote-bg">
                 <a href="http://twitter.com/billymeinke">
                   <img class="media-object" src="./img/speakers/billy.jpg" alt="Billy Meinke">
                 </a>
               </div>
-              <div class="media-body">
+              <div class="media-body keynote-bg">
                 <h4 class="media-heading">Billy Meinke – Open Education & Creative Commons (INTL)</h4>
                 <p>
                   Billy is an education technologist supporting collaboration and knowledge sharing across open education initiatives on the web. He formerly worked at Creative Commons, supporting stakeholders in the world’s largest OER project in higher education and workforce training and now spends much of his time looking for new ways to leverage the web for global good.
                 </p>
+                <h4 class="keynote-tag">Keynote Speaker</h4>
               </div>
             </div>
 
-            <div class="media speaker-keynote">
-              <div class="media-left">
+            <div class="media speaker-keynote keynote-bg">
+              <div class="media-left keynote-bg">
                 <a href="http://twitter.com/keithabooth">
                   <img class="media-object" src="./img/speakers/keitha.jpg" alt="Keitha Booth">
                 </a>
               </div>
-              <div class="media-body">
+              <div class="media-body keynote-bg">
                 <h4 class="media-heading">Keitha Booth – Manager, NZ Open Government Data Programme (NZ)</h4>
                 <p>
                   Keitha Booth manages the NZ Open Government Information and Data Programme, based at Land Information New Zealand. She has led this programme since 2009 and driven the development of the Declaration on Open and Transparent Government, the New Zealand Government Open Access and Licensing framework (NZGOAL) and the New Zealand Data and Information Management Principles (NZDIMP). Her earlier roles include Communications and Relationships Manager, E-government Unit, State Services Commission; Information Manager, National Library of New Zealand; Information Manager, Ministry for Economic Development and Lead Consultant, Beca Group, providing information related advice to clients.
@@ -452,6 +458,7 @@
                 <p>
                   Keitha is on the Advisory Boards of Creative Commons Aotearoa NZ and Digital New Zealand.  She has post graduate qualifications in librarianship and information systems.
                 </p>
+                <h4 class="keynote-tag">Keynote Speaker</h4>
               </div>
             </div>
 

--- a/speakers.html
+++ b/speakers.html
@@ -118,7 +118,7 @@
         <div class="col-lg-6">
           <div class="media">
             <div class="media-left">
-              <a href="http://twitter.com/BenBalter">
+              <a target="_blank" href="http://twitter.com/BenBalter">
                 <img class="media-object" src="./img/speakers/ben.jpg" alt="Ben Balter">
               </a>
             </div>
@@ -132,7 +132,7 @@
 
           <div class="media">
             <div class="media-left">
-              <a href="http://twitter.com/">
+              <a target="_blank" href="https://twitter.com/RichDecibels">
                 <img class="media-object" src="./img/speakers/rich.jpg" alt="Rich Bartlet">
               </a>
             </div>
@@ -146,7 +146,7 @@
 
           <div class="media speaker-keynote keynote-bg">
             <div class="media-left keynote-bg">
-              <a href="http://twitter.com/bkeepers">
+              <a target="_blank" href="http://twitter.com/bkeepers">
                 <img class="media-object" src="./img/speakers/brandon.jpg" alt="Brandon Keepers">
               </a>
             </div>
@@ -162,7 +162,7 @@
 
           <div class="media">
             <div class="media-left">
-              <a href="http://twitter.com/">
+              <a target="_blank" href="https://twitter.com/redshifter3">
                 <img class="media-object" src="./img/speakers/doug.jpg" alt="Doug Kirkpatrick">
               </a>
             </div>
@@ -179,7 +179,7 @@
 
           <div class="media speaker-keynote keynote-bg">
             <div class="media-left keynote-bg">
-              <a href="http://twitter.com/">
+              <a target="_blank" href="http://craftworks.enspiral.com/">
                 <img class="media-object" src="./img/speakers/craig.jpg" alt="Craig Ambrose">
               </a>
             </div>
@@ -194,7 +194,7 @@
 
           <div class="media">
             <div class="media-left">
-              <a href="http://twitter.com/jllord">
+              <a target="_blank" href="http://twitter.com/jllord">
                 <img class="media-object" src="./img/speakers/jessica.jpg" alt="Jessica Lorde">
               </a>
             </div>
@@ -208,7 +208,7 @@
 
           <div class="media">
             <div class="media-left">
-              <a href="http://twitter.com/">
+              <a target="_blank" href="https://twitter.com/linzlds">
                 <img class="media-object" src="./img/speakers/jeremy.jpg" alt="Josh Vial">
               </a>
             </div>
@@ -224,7 +224,7 @@
 
           <div class="media">
             <div class="media-left">
-              <a href="http://twitter.com/">
+              <a target="_blank" href="https://twitter.com/joshuavial">
                 <img class="media-object" src="./img/speakers/josh_vial.jpg" alt="Jeremy Palmer">
               </a>
             </div>
@@ -238,7 +238,7 @@
 
           <div class="media speaker-keynote keynote-bg">
             <div class="media-left keynote-bg">
-              <a href="http://twitter.com/lightweight">
+              <a target="_blank" href="http://twitter.com/lightweight">
                 <img class="media-object" src="./img/speakers/dave_lane.jpg" alt="Dave Lane">
               </a>
             </div>
@@ -264,7 +264,7 @@
 
           <div class="media">
             <div class="media-left">
-              <a href="http://twitter.com/nathansobo">
+              <a target="_blank" href="http://twitter.com/nathansobo">
                 <img class="media-object" src="./img/speakers/nathan.jpg" alt="Nathan Sobo">
               </a>
             </div>
@@ -278,7 +278,7 @@
 
           <div class="media">
             <div class="media-left">
-              <a href="http://twitter.com/alannakrause">
+              <a target="_blank" href="https://twitter.com/zenpeacekeeper">
                 <img class="media-object" src="./img/speakers/marianne.jpg" alt="Marianne Elliott">
               </a>
             </div>
@@ -292,7 +292,7 @@
 
           <div class="media">
             <div class="media-left">
-              <a href="http://twitter.com/">
+              <a target="_blank" href="http://www.springload.co.nz/people/josh-barr/">
                 <img class="media-object" src="./img/speakers/josh_barr.jpg" alt="Josh Barr">
               </a>
             </div>
@@ -309,7 +309,7 @@
 
           <div class="media">
             <div class="media-left">
-              <a href="http://twitter.com/">
+              <a target="_blank" href="https://twitter.com/vikolliver">
                 <img class="media-object" src="./img/speakers/vik.jpg" alt="Vik Olliver">
               </a>
             </div>
@@ -345,7 +345,7 @@
 
             <div class="media">
               <div class="media-left">
-                <a href="http://twitter.com/miramarmike">
+                <a target="_blank" href="http://twitter.com/miramarmike">
                   <img class="media-object" src="./img/speakers/mike.jpg" alt="Mike Riversdale">
                 </a>
               </div>
@@ -359,7 +359,7 @@
 
             <div class="media">
               <div class="media-left">
-                <a href="http://twitter.com/">
+                <a target="_blank" href="https://twitter.com/cameronfindlay">
                   <img class="media-object" src="./img/speakers/cam.jpg" alt="Cam Findlay">
                 </a>
               </div>
@@ -373,7 +373,7 @@
 
             <div class="media">
               <div class="media-left">
-                <a href="http://twitter.com/alannakrause">
+                <a target="_blank" href="http://twitter.com/alannakrause">
                   <img class="media-object" src="./img/speakers/alanna.jpg" alt="Alanna Krause">
                 </a>
               </div>
@@ -387,7 +387,7 @@
 
             <div class="media">
               <div class="media-left">
-                <a href="http://twitter.com/amateurhuman">
+                <a target="_blank" href="http://twitter.com/amateurhuman">
                   <img class="media-object" src="./img/speakers/chris.jpg" alt="Chris Kelly">
                 </a>
               </div>
@@ -402,7 +402,7 @@
 
             <div class="media">
               <div class="media-left">
-                <a href="http://twitter.com/chelsea">
+                <a target="_blank" href="https://twitter.com/chelsearobnson">
                   <img class="media-object" src="./img/speakers/chelsea_robinson.jpg" alt="Chelsea Robinson">
                 </a>
               </div>
@@ -416,7 +416,7 @@
 
             <div class="media speaker-keynote keynote-bg">
               <div class="media-left keynote-bg">
-                <a href="http://twitter.com/saschameinrath">
+                <a target="_blank" href="http://twitter.com/saschameinrath">
                   <img class="media-object" src="./img/speakers/sascha.jpg" alt="Sascha Meinrath">
                 </a>
               </div>
@@ -431,7 +431,7 @@
 
             <div class="media speaker-keynote keynote-bg">
               <div class="media-left keynote-bg">
-                <a href="http://twitter.com/billymeinke">
+                <a target="_blank" href="http://twitter.com/billymeinke">
                   <img class="media-object" src="./img/speakers/billy.jpg" alt="Billy Meinke">
                 </a>
               </div>
@@ -446,7 +446,7 @@
 
             <div class="media speaker-keynote keynote-bg">
               <div class="media-left keynote-bg">
-                <a href="http://twitter.com/keithabooth">
+                <a target="_blank" href="http://twitter.com/keithabooth">
                   <img class="media-object" src="./img/speakers/keitha.jpg" alt="Keitha Booth">
                 </a>
               </div>
@@ -464,7 +464,7 @@
 
             <div class="media">
               <div class="media-left">
-                <a href="http://twitter.com/ranginui">
+                <a target="_blank" href="http://twitter.com/ranginui">
                   <img class="media-object" src="./img/speakers/chris_cormack.jpg" alt="Chris Cormack">
                 </a>
               </div>
@@ -478,7 +478,7 @@
 
             <div class="media">
               <div class="media-left">
-                <a href="http://twitter.com/gracefullillian">
+                <a target="_blank" href="http://twitter.com/gracefullillian">
                   <img class="media-object" src="./img/speakers/lillian.jpg" alt="Lillian Grace">
                 </a>
               </div>


### PR DESCRIPTION
Tidy up the speakers page: 
- improve highlighting of keynote speakers
- fix the missing and broken twitter links attached to bio photos
- launch twitter links in new window / tab so we don't lose visitors from the osos site. 
